### PR TITLE
Revert assembly name to AWSSDK.Extensions.S3.Encryption

### DIFF
--- a/src/Amazon.Extensions.S3.Encryption.csproj
+++ b/src/Amazon.Extensions.S3.Encryption.csproj
@@ -15,6 +15,9 @@
         <PackageIcon>icon.png</PackageIcon>
         <RepositoryUrl>https://github.com/aws/amazon-s3-encryption-client-dotnet/</RepositoryUrl>
         <Company>Amazon Web Services</Company>
+
+        <!-- Do not change assembly name, changing assembly name is a breaking change -->
+        <AssemblyName>AWSSDK.Extensions.S3.Encryption</AssemblyName>
         <AssemblyVersion>1.0.0</AssemblyVersion>
         <FileVersion>1.0.0</FileVersion>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
As part of https://github.com/aws/amazon-s3-encryption-client-dotnet/pull/2/, due to renaming AWSSDK.Extensions.S3.Encryption.csproj to Amazon.Extensions.S3.Encryption.csproj assembly name was also changed to Amazon.Extensions.S3.Encryption. Which is breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
