### PR TITLE
Fix issue creating KMS Client

### DIFF
--- a/src/Amazon.Extensions.S3.Encryption.csproj
+++ b/src/Amazon.Extensions.S3.Encryption.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net35;net45;netstandard1.3;netstandard2.0;netcoreapp3.1</TargetFrameworks>
-        <Version>1.1.0</Version>
+        <Version>1.2.0</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Amazon.Extensions.S3.Encryption</PackageId>
         <Title>Amazon S3 Encryption Client for .NET</Title>
@@ -15,8 +15,8 @@
         <PackageIcon>icon.png</PackageIcon>
         <RepositoryUrl>https://github.com/aws/amazon-s3-encryption-client-dotnet/</RepositoryUrl>
         <Company>Amazon Web Services</Company>
-        <AssemblyVersion>1.1.0</AssemblyVersion>
-        <FileVersion>1.1.0</FileVersion>
+        <AssemblyVersion>1.2.0</AssemblyVersion>
+        <FileVersion>1.2.0</FileVersion>
 
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>

--- a/src/AmazonS3EncryptionClientBase.cs
+++ b/src/AmazonS3EncryptionClientBase.cs
@@ -60,7 +60,6 @@ namespace Amazon.Extensions.S3.Encryption
                                 kmsConfig.SetWebProxy(proxySettings);
                             }
                             
-
                             kmsClient = new AmazonKeyManagementServiceClient(Credentials, kmsConfig);
                         }
                     }

--- a/src/AmazonS3EncryptionClientBase.cs
+++ b/src/AmazonS3EncryptionClientBase.cs
@@ -48,7 +48,21 @@ namespace Amazon.Extensions.S3.Encryption
                     lock (kmsClientLock)
                     {
                         if (kmsClient == null)
-                            kmsClient = new AmazonKeyManagementServiceClient();
+                        {
+                            var kmsConfig = new AmazonKeyManagementServiceConfig
+                            {
+                                RegionEndpoint = this.Config.RegionEndpoint
+                            };
+
+                            var proxySettings = this.Config.GetWebProxy();
+                            if(proxySettings != null)
+                            {
+                                kmsConfig.SetWebProxy(proxySettings);
+                            }
+                            
+
+                            kmsClient = new AmazonKeyManagementServiceClient(Credentials, kmsConfig);
+                        }
                     }
                 }
                 return kmsClient;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-s3-encryption-client-dotnet/issues/6

*Description of changes:*
The KMS client was being created using the SDK default credentials search. It needs to be created using the same credentials, region and proxy settings as the S3 client that is creating the KMS client.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
