### PR TITLE
netstandard 1.3 support removed

### DIFF
--- a/src/Amazon.Extensions.S3.Encryption.csproj
+++ b/src/Amazon.Extensions.S3.Encryption.csproj
@@ -41,9 +41,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.Core" Version="3.3.107.35" />
-        <PackageReference Include="AWSSDK.S3" Version="3.3.111.37" />
-        <PackageReference Include="AWSSDK.KeyManagementService" Version="3.3.106.30" />
+        <PackageReference Include="AWSSDK.Core" Version="3.7.0" />
+        <PackageReference Include="AWSSDK.S3" Version="3.7.0" />
+        <PackageReference Include="AWSSDK.KeyManagementService" Version="3.7.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net35'">

--- a/src/Amazon.Extensions.S3.Encryption.csproj
+++ b/src/Amazon.Extensions.S3.Encryption.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net35;net45;netstandard1.3;netstandard2.0;netcoreapp3.1</TargetFrameworks>
-        <Version>1.2.1</Version>
+        <TargetFrameworks>net35;net45;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+        <Version>1.3.0</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Amazon.Extensions.S3.Encryption</PackageId>
         <Title>Amazon S3 Encryption Client for .NET</Title>
@@ -15,8 +15,8 @@
         <PackageIcon>icon.png</PackageIcon>
         <RepositoryUrl>https://github.com/aws/amazon-s3-encryption-client-dotnet/</RepositoryUrl>
         <Company>Amazon Web Services</Company>
-        <AssemblyVersion>1.2.1</AssemblyVersion>
-        <FileVersion>1.2.1</FileVersion>
+        <AssemblyVersion>1.3.0</AssemblyVersion>
+        <FileVersion>1.3.0</FileVersion>
 
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>
@@ -36,7 +36,6 @@
     <PropertyGroup>
         <DefineConstants Condition="'$(TargetFramework)' == 'net35'">$(DefineConstants);BCL;BCL35;AWS_APM_API</DefineConstants>
         <DefineConstants Condition="'$(TargetFramework)' == 'net45'">$(DefineConstants);BCL;BCL45;AWS_ASYNC_API</DefineConstants>
-        <DefineConstants Condition="'$(TargetFramework)' == 'netstandard1.3'">$(DefineConstants);NETSTANDARD;AWS_ASYNC_API</DefineConstants>
         <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.0'">$(DefineConstants);NETSTANDARD;AWS_ASYNC_API</DefineConstants>
         <DefineConstants Condition="'$(TargetFramework)' == 'netcoreapp3.1'">$(DefineConstants);NETSTANDARD;AWS_ASYNC_API</DefineConstants>
     </PropertyGroup>
@@ -49,10 +48,6 @@
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net35'">
         <PackageReference Include="BouncyCastle" Version="1.8.9" />
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-        <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netcoreapp3.1'">

--- a/src/Amazon.Extensions.S3.Encryption.csproj
+++ b/src/Amazon.Extensions.S3.Encryption.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net35;net45;netstandard2.0;netcoreapp3.1</TargetFrameworks>
-        <Version>1.3.0</Version>
+        <Version>2.0.0</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Amazon.Extensions.S3.Encryption</PackageId>
         <Title>Amazon S3 Encryption Client for .NET</Title>
@@ -15,8 +15,8 @@
         <PackageIcon>icon.png</PackageIcon>
         <RepositoryUrl>https://github.com/aws/amazon-s3-encryption-client-dotnet/</RepositoryUrl>
         <Company>Amazon Web Services</Company>
-        <AssemblyVersion>1.3.0</AssemblyVersion>
-        <FileVersion>1.3.0</FileVersion>
+        <AssemblyVersion>2.0.0</AssemblyVersion>
+        <FileVersion>2.0.0</FileVersion>
 
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>

--- a/test/IntegrationTests/Amazon.Extensions.S3.Encryption.IntegrationTests.NetFramework.csproj
+++ b/test/IntegrationTests/Amazon.Extensions.S3.Encryption.IntegrationTests.NetFramework.csproj
@@ -19,12 +19,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.Core" Version="3.3.107.35" />
-        <PackageReference Include="AWSSDK.S3" Version="3.3.111.37" />
-        <PackageReference Include="AWSSDK.KeyManagementService" Version="3.3.106.30" />
-        <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.105.38" />
-        <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.102.11" />
-        <PackageReference Include="AWSSDK.ResourceGroupsTaggingAPI" Version="3.3.103.113" />
+        <PackageReference Include="AWSSDK.Core" Version="3.7.0" />
+        <PackageReference Include="AWSSDK.S3" Version="3.7.0" />
+        <PackageReference Include="AWSSDK.KeyManagementService" Version="3.7.0" />
+        <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0" />
+        <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.0" />
+        <PackageReference Include="AWSSDK.ResourceGroupsTaggingAPI" Version="3.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
         <PackageReference Include="xunit" Version="1.9.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/test/IntegrationTests/Amazon.Extensions.S3.Encryption.IntegrationTests.NetStandard.csproj
+++ b/test/IntegrationTests/Amazon.Extensions.S3.Encryption.IntegrationTests.NetStandard.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
         <IsPackable>false</IsPackable>
 
         <!-- workaround per https://github.com/Microsoft/msbuild/issues/1333 -->

--- a/test/IntegrationTests/Amazon.Extensions.S3.Encryption.IntegrationTests.NetStandard.csproj
+++ b/test/IntegrationTests/Amazon.Extensions.S3.Encryption.IntegrationTests.NetStandard.csproj
@@ -15,12 +15,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.Core" Version="3.3.107.35" />
-        <PackageReference Include="AWSSDK.S3" Version="3.3.111.37" />
-        <PackageReference Include="AWSSDK.KeyManagementService" Version="3.3.106.30" />
-        <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.105.38" />
-        <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.3.102.11" />
-        <PackageReference Include="AWSSDK.ResourceGroupsTaggingAPI" Version="3.3.103.113" />
+        <PackageReference Include="AWSSDK.Core" Version="3.7.0" />
+        <PackageReference Include="AWSSDK.S3" Version="3.7.0" />
+        <PackageReference Include="AWSSDK.KeyManagementService" Version="3.7.0" />
+        <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.0" />
+        <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.0" />
+        <PackageReference Include="AWSSDK.ResourceGroupsTaggingAPI" Version="3.7.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/test/UnitTests/Amazon.Extensions.S3.Encryption.UnitTests.csproj
+++ b/test/UnitTests/Amazon.Extensions.S3.Encryption.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>net35;net45;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
+        <TargetFrameworks>net35;net45;netcoreapp2.1</TargetFrameworks>
         <DefineConstants Condition="'$(TargetFramework)' == 'net35'">$(DefineConstants);DEBUG;TRACE;BCL;BCL35;AWS_APM_API</DefineConstants>
         <DefineConstants Condition="'$(TargetFramework)' == 'net45'">$(DefineConstants);DEBUG;TRACE;BCL;BCL45;ASYNC_AWAIT;</DefineConstants>
         <DefineConstants Condition="'$(TargetFramework)' == 'netcoreapp2.0'">$(DefineConstants);NETSTANDARD;AWS_ASYNC_API</DefineConstants>
@@ -8,7 +8,11 @@
 
         <!-- workaround per https://github.com/Microsoft/msbuild/issues/1333 -->
         <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
-    </PropertyGroup>
+
+        <!-- workaround per https://github.com/dotnet/msbuild/issues/5985 -->
+        <AutomaticallyUseReferenceAssemblyPackages Condition=" '$(TargetFramework)' == 'net35' ">false</AutomaticallyUseReferenceAssemblyPackages>
+
+	</PropertyGroup>
 
     <ItemGroup>
         <Compile Remove="**/obj/**" />
@@ -18,7 +22,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
         <PackageReference Condition="'$(TargetFramework)' == 'net35' Or '$(TargetFramework)' == 'net45'" Include="xunit.extensions" Version="1.9.2" />
-        <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.1' Or '$(TargetFramework)' == 'netcoreapp1.1'" Include="xunit" Version="2.4.1" />
+        <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.1'" Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     </ItemGroup>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* netstandard 1.3 support removed
* enabled net 5 build
* minor version increased

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open [issue][issues], please link to the issue here -->

To disable targeting netstandard 1.3 (discontinued support)
To enabled net 5 build for net3.5 target

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local build is successful (net 5) and unit tests are green

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement