### PR TITLE
Added ability to handle CalculateContentMD5Header flag for S3 uploads.

### DIFF
--- a/src/Amazon.Extensions.S3.Encryption.csproj
+++ b/src/Amazon.Extensions.S3.Encryption.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net35;net45;netstandard2.0;netcoreapp3.1</TargetFrameworks>
-        <Version>2.0.1</Version>
+        <Version>2.0.2</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Amazon.Extensions.S3.Encryption</PackageId>
         <Title>Amazon S3 Encryption Client for .NET</Title>
@@ -15,8 +15,8 @@
         <PackageIcon>icon.png</PackageIcon>
         <RepositoryUrl>https://github.com/aws/amazon-s3-encryption-client-dotnet/</RepositoryUrl>
         <Company>Amazon Web Services</Company>
-        <AssemblyVersion>2.0.1</AssemblyVersion>
-        <FileVersion>2.0.1</FileVersion>
+        <AssemblyVersion>2.0.2</AssemblyVersion>
+        <FileVersion>2.0.2</FileVersion>
 
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>
@@ -41,9 +41,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.Core" Version="3.7.0.12" />
-        <PackageReference Include="AWSSDK.S3" Version="3.7.0.13" />
-        <PackageReference Include="AWSSDK.KeyManagementService" Version="3.7.0.11" />
+        <PackageReference Include="AWSSDK.Core" Version="3.7.0.31" />
+        <PackageReference Include="AWSSDK.S3" Version="3.7.0.32" />
+        <PackageReference Include="AWSSDK.KeyManagementService" Version="3.7.0.29" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net35'">

--- a/src/EncryptionUtilsV2.cs
+++ b/src/EncryptionUtilsV2.cs
@@ -113,12 +113,18 @@ namespace Amazon.Extensions.S3.Encryption
         /// <param name="instructions">
         /// The instruction that will be used to encrypt the object data.
         /// </param>
+        /// <param name="shouldUseCachingStream">
+        /// Flag indicating if the caching stream should be used or not.
+        /// </param>
         /// <returns>
         /// Encrypted stream, i.e input stream wrapped into encrypted stream
         /// </returns>
-        internal static Stream EncryptRequestUsingInstructionV2(Stream toBeEncrypted, EncryptionInstructions instructions)
+        internal static Stream EncryptRequestUsingInstructionV2(Stream toBeEncrypted, EncryptionInstructions instructions, bool shouldUseCachingStream)
         {
-            Stream gcmEncryptStream = new AesGcmEncryptStream(toBeEncrypted, instructions.EnvelopeKey, instructions.InitializationVector, DefaultTagBitsLength);
+            Stream gcmEncryptStream = (shouldUseCachingStream ? 
+                                        new AesGcmEncryptCachingStream(toBeEncrypted, instructions.EnvelopeKey, instructions.InitializationVector, DefaultTagBitsLength)
+                                        : new AesGcmEncryptStream(toBeEncrypted, instructions.EnvelopeKey, instructions.InitializationVector, DefaultTagBitsLength)
+                                       );
             return gcmEncryptStream;
         }
 

--- a/src/Internal/SetupEncryptionHandlerV2.cs
+++ b/src/Internal/SetupEncryptionHandlerV2.cs
@@ -60,7 +60,7 @@ using Amazon.Runtime;
             EncryptionUtils.AddUnencryptedContentLengthToMetadata(putObjectRequest);
 
             // Encrypt the object data with the instruction
-            putObjectRequest.InputStream = EncryptionUtils.EncryptRequestUsingInstructionV2(putObjectRequest.InputStream, instructions);
+            putObjectRequest.InputStream = EncryptionUtils.EncryptRequestUsingInstructionV2(putObjectRequest.InputStream, instructions, putObjectRequest.CalculateContentMD5Header);
 
             // Create request for uploading instruction file 
             PutObjectRequest instructionFileRequest = EncryptionUtils.CreateInstructionFileRequestV2(putObjectRequest, instructions);
@@ -93,7 +93,7 @@ using Amazon.Runtime;
             EncryptionUtils.AddUnencryptedContentLengthToMetadata(putObjectRequest);
 
             // Encrypt the object data with the instruction
-            putObjectRequest.InputStream = EncryptionUtils.EncryptRequestUsingInstructionV2(putObjectRequest.InputStream, instructions);
+            putObjectRequest.InputStream = EncryptionUtils.EncryptRequestUsingInstructionV2(putObjectRequest.InputStream, instructions, putObjectRequest.CalculateContentMD5Header);
 
             // Update the metadata
             EncryptionUtils.UpdateMetadataWithEncryptionInstructionsV2(putObjectRequest, instructions, EncryptionClient);

--- a/test/IntegrationTests/_bcl/EncryptionTestsV2.cs
+++ b/test/IntegrationTests/_bcl/EncryptionTestsV2.cs
@@ -172,6 +172,13 @@ namespace Amazon.Extensions.S3.Encryption.IntegrationTests
 
         [Fact]
         [Trait(CategoryAttribute, "S3")]
+        public void TestTransferUtilityS3EncryptionClientMetadataModeKMSCalculateMD5()
+        {
+            EncryptionTestsUtils.TestTransferUtilityCalculateMD5(s3EncryptionClientMetadataModeKMS, s3EncryptionClientMetadataModeKMS, bucketName);
+        }
+
+        [Fact]
+        [Trait(CategoryAttribute, "S3")]
         public void PutGetFileUsingMetadataModeAsymmetricWrap()
         {
             EncryptionTestsUtils.TestPutGet(s3EncryptionClientMetadataModeAsymmetricWrap, filePath, null, null,
@@ -359,6 +366,13 @@ namespace Amazon.Extensions.S3.Encryption.IntegrationTests
 
         [Fact]
         [Trait(CategoryAttribute, "S3")]
+        public void PutGetNullContentContentUsingMetadataModeKMSCalculateMD5()
+        {
+            EncryptionTestsUtils.TestPutGetCalculateMD5(s3EncryptionClientMetadataModeKMS, s3EncryptionClientMetadataModeKMS, null, null, null, "", bucketName);
+        }
+
+        [Fact]
+        [Trait(CategoryAttribute, "S3")]
         public void MultipartEncryptionTestMetadataModeSymmetricWrap()
         {
             EncryptionTestsUtils.MultipartEncryptionTest(s3EncryptionClientMetadataModeSymmetricWrap, bucketName);
@@ -399,6 +413,13 @@ namespace Amazon.Extensions.S3.Encryption.IntegrationTests
             AssertExtensions.ExpectException(
                 () => { EncryptionTestsUtils.MultipartEncryptionTest(s3EncryptionClientFileModeKMS, bucketName); },
                 typeof(AmazonClientException), InstructionAndKMSErrorMessage);
+        }
+
+        [Fact]
+        [Trait(CategoryAttribute, "S3")]
+        public void MultipartEncryptionTestMetadataModeKMSCalculateMD5()
+        {
+            EncryptionTestsUtils.MultipartEncryptionTestCalculateMD5(s3EncryptionClientMetadataModeKMS, s3EncryptionClientMetadataModeKMS, bucketName);
         }
 
 #if AWS_APM_API

--- a/test/IntegrationTests/netstandard/EncryptionTestsV2.cs
+++ b/test/IntegrationTests/netstandard/EncryptionTestsV2.cs
@@ -359,6 +359,14 @@ namespace Amazon.Extensions.S3.Encryption.IntegrationTests
 
         [Fact]
         [Trait(CategoryAttribute, "S3")]
+        public async Task PutGetNullContentContentUsingMetadataModeKMSCalculateMD5()
+        {
+            await EncryptionTestsUtils.TestPutGetCalculateMD5Async(s3EncryptionClientMetadataModeKMS, s3EncryptionClientMetadataModeKMS, null, null,
+                null, "", bucketName).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [Trait(CategoryAttribute, "S3")]
         public void PutGetContentUsingInstructionFileModeKMS()
         {
             AssertExtensions.ExpectException(() =>
@@ -405,6 +413,13 @@ namespace Amazon.Extensions.S3.Encryption.IntegrationTests
         public async Task MultipartEncryptionTestMetadataModeKMS()
         {
             await EncryptionTestsUtils.MultipartEncryptionTestAsync(s3EncryptionClientMetadataModeKMS, bucketName);
+        }
+
+        [Fact]
+        [Trait(CategoryAttribute, "S3")]
+        public async Task MultipartEncryptionTestMetadataModeKMSCalculateMD5()
+        {
+            await EncryptionTestsUtils.MultipartEncryptionTestCalculateMD5Async(s3EncryptionClientMetadataModeKMS, s3EncryptionClientMetadataModeKMS, bucketName);
         }
 
         [Fact]

--- a/test/IntegrationTests/netstandard/Utilities/EncryptionTestsUtils.cs
+++ b/test/IntegrationTests/netstandard/Utilities/EncryptionTestsUtils.cs
@@ -167,6 +167,144 @@ namespace Amazon.Extensions.S3.Encryption.IntegrationTests.Utilities
             }
         }
 
+        public static async Task MultipartEncryptionTestCalculateMD5Async(AmazonS3Client s3EncryptionClient,
+            AmazonS3Client s3DecryptionClient, string bucketName)
+        {
+            var filePath = Path.GetTempFileName();
+            var retrievedFilepath = Path.GetTempFileName();
+            var totalSize = MegaBytesSize * 15;
+
+            UtilityMethods.GenerateFile(filePath, totalSize);
+            var key = Guid.NewGuid().ToString();
+
+            Stream inputStream = File.OpenRead(filePath);
+            try
+            {
+                InitiateMultipartUploadRequest initRequest = new InitiateMultipartUploadRequest()
+                {
+                    BucketName = bucketName,
+                    Key = key,
+                    StorageClass = S3StorageClass.OneZoneInfrequentAccess,
+                    ContentType = "text/html",
+                };
+
+                InitiateMultipartUploadResponse initResponse =
+                    await s3EncryptionClient.InitiateMultipartUploadAsync(initRequest).ConfigureAwait(false);
+
+                // Upload part 1
+                UploadPartRequest uploadRequest = new UploadPartRequest()
+                {
+                    BucketName = bucketName,
+                    Key = key,
+                    UploadId = initResponse.UploadId,
+                    PartNumber = 1,
+                    PartSize = 5 * MegaBytesSize,
+                    InputStream = inputStream,
+                    CalculateContentMD5Header = true
+                };
+
+                UploadPartResponse up1Response =
+                    await s3EncryptionClient.UploadPartAsync(uploadRequest).ConfigureAwait(false);
+
+                // Upload part 2
+                uploadRequest = new UploadPartRequest()
+                {
+                    BucketName = bucketName,
+                    Key = key,
+                    UploadId = initResponse.UploadId,
+                    PartNumber = 2,
+                    PartSize = 5 * MegaBytesSize,
+                    InputStream = inputStream,
+                    CalculateContentMD5Header = true
+                };
+
+                UploadPartResponse up2Response =
+                    await s3EncryptionClient.UploadPartAsync(uploadRequest).ConfigureAwait(false);
+
+                // Upload part 3
+                uploadRequest = new UploadPartRequest()
+                {
+                    BucketName = bucketName,
+                    Key = key,
+                    UploadId = initResponse.UploadId,
+                    PartNumber = 3,
+                    InputStream = inputStream,
+                    IsLastPart = true,
+                    CalculateContentMD5Header = true
+                };
+
+                UploadPartResponse up3Response =
+                    await s3EncryptionClient.UploadPartAsync(uploadRequest).ConfigureAwait(false);
+
+                ListPartsRequest listPartRequest = new ListPartsRequest()
+                {
+                    BucketName = bucketName,
+                    Key = key,
+                    UploadId = initResponse.UploadId
+                };
+
+                ListPartsResponse listPartResponse =
+                    await s3EncryptionClient.ListPartsAsync(listPartRequest).ConfigureAwait(false);
+                Assert.Equal(3, listPartResponse.Parts.Count);
+                Assert.Equal(up1Response.PartNumber, listPartResponse.Parts[0].PartNumber);
+                Assert.Equal(up1Response.ETag, listPartResponse.Parts[0].ETag);
+                Assert.Equal(up2Response.PartNumber, listPartResponse.Parts[1].PartNumber);
+                Assert.Equal(up2Response.ETag, listPartResponse.Parts[1].ETag);
+                Assert.Equal(up3Response.PartNumber, listPartResponse.Parts[2].PartNumber);
+                Assert.Equal(up3Response.ETag, listPartResponse.Parts[2].ETag);
+
+                listPartRequest.MaxParts = 1;
+                listPartResponse = await s3EncryptionClient.ListPartsAsync(listPartRequest).ConfigureAwait(false);
+                Assert.Single(listPartResponse.Parts);
+
+                // Complete the response
+                CompleteMultipartUploadRequest compRequest = new CompleteMultipartUploadRequest()
+                {
+                    BucketName = bucketName,
+                    Key = key,
+                    UploadId = initResponse.UploadId
+                };
+                compRequest.AddPartETags(up1Response, up2Response, up3Response);
+
+                CompleteMultipartUploadResponse compResponse =
+                    await s3EncryptionClient.CompleteMultipartUploadAsync(compRequest).ConfigureAwait(false);
+                Assert.Equal(bucketName, compResponse.BucketName);
+                Assert.NotNull(compResponse.ETag);
+                Assert.Equal(key, compResponse.Key);
+                Assert.NotNull(compResponse.Location);
+
+                // Get the file back from S3 and make sure it is still the same.
+                GetObjectRequest getRequest = new GetObjectRequest()
+                {
+                    BucketName = bucketName,
+                    Key = key
+                };
+
+                GetObjectResponse getResponse =
+                    await s3DecryptionClient.GetObjectAsync(getRequest).ConfigureAwait(false);
+                await getResponse.WriteResponseStreamToFileAsync(retrievedFilepath, false, CancellationToken.None);
+
+                UtilityMethods.CompareFiles(filePath, retrievedFilepath);
+
+                GetObjectMetadataRequest metaDataRequest = new GetObjectMetadataRequest()
+                {
+                    BucketName = bucketName,
+                    Key = key
+                };
+                GetObjectMetadataResponse metaDataResponse =
+                    await s3DecryptionClient.GetObjectMetadataAsync(metaDataRequest).ConfigureAwait(false);
+                Assert.Equal("text/html", metaDataResponse.Headers.ContentType);
+            }
+            finally
+            {
+                inputStream.Dispose();
+                if (File.Exists(filePath))
+                    File.Delete(filePath);
+                if (File.Exists(retrievedFilepath))
+                    File.Delete(retrievedFilepath);
+            }
+        }
+
         public static async Task TestPutGetAsync(AmazonS3Client s3EncryptionClient,
             string filePath, byte[] inputStreamBytes, string contentBody, string expectedContent, string bucketName)
         {
@@ -184,6 +322,22 @@ namespace Amazon.Extensions.S3.Encryption.IntegrationTests.Utilities
                 FilePath = filePath,
                 InputStream = inputStreamBytes == null ? null : new MemoryStream(inputStreamBytes),
                 ContentBody = contentBody,
+            };
+            PutObjectResponse response = await s3EncryptionClient.PutObjectAsync(request).ConfigureAwait(false);
+            await TestGetAsync(request.Key, expectedContent, s3DecryptionClient, bucketName).ConfigureAwait(false);
+        }
+
+        public static async Task TestPutGetCalculateMD5Async(AmazonS3Client s3EncryptionClient, AmazonS3Client s3DecryptionClient,
+            string filePath, byte[] inputStreamBytes, string contentBody, string expectedContent, string bucketName)
+        {
+            PutObjectRequest request = new PutObjectRequest()
+            {
+                BucketName = bucketName,
+                Key = $"key-{Guid.NewGuid()}",
+                FilePath = filePath,
+                InputStream = inputStreamBytes == null ? null : new MemoryStream(inputStreamBytes),
+                ContentBody = contentBody,
+                CalculateContentMD5Header = true
             };
             PutObjectResponse response = await s3EncryptionClient.PutObjectAsync(request).ConfigureAwait(false);
             await TestGetAsync(request.Key, expectedContent, s3DecryptionClient, bucketName).ConfigureAwait(false);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added ability to handle CalculateContentMD5Header flag for S3 uploads.

## Motivation and Context

## Testing
- Added new integration tests.
- Ran integration tests locally.

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement