### PR TITLE
AmazonKeyManagementServiceConfig doesn't use the service url when it's setting on AmazonS3CryptoConfigurationV2

### DIFF
--- a/src/AmazonS3EncryptionClientBase.cs
+++ b/src/AmazonS3EncryptionClientBase.cs
@@ -51,8 +51,14 @@ namespace Amazon.Extensions.S3.Encryption
                         {
                             var kmsConfig = new AmazonKeyManagementServiceConfig
                             {
-                                RegionEndpoint = this.Config.RegionEndpoint
+                                RegionEndpoint = this.Config.RegionEndpoint,
+                                UseHttp = this.Config.UseHttp
                             };
+
+                            if (this.Config.ServiceURL != null)
+                            {
+                                kmsConfig.ServiceURL = this.Config.ServiceURL;
+                            }
 
                             var proxySettings = this.Config.GetWebProxy();
                             if(proxySettings != null)


### PR DESCRIPTION
AmazonKeyManagementServiceConfig doesn't use the service url when it's setting on AmazonS3CryptoConfigurationV2

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
I'm using LocalStack when I set ServiceURL on AmazonS3CryptoConfigurationV2 I'm seeing the Kms calling aws endpoint

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement