### PR TITLE
Set KMS client timeout using S3Client Config so that a timeout set on…

### DIFF
--- a/src/AmazonS3EncryptionClientBase.cs
+++ b/src/AmazonS3EncryptionClientBase.cs
@@ -51,7 +51,8 @@ namespace Amazon.Extensions.S3.Encryption
                         {
                             var kmsConfig = new AmazonKeyManagementServiceConfig
                             {
-                                RegionEndpoint = this.Config.RegionEndpoint
+                                RegionEndpoint = this.Config.RegionEndpoint,
+                                Timeout = this.Config.Timeout
                             };
 
                             var proxySettings = this.Config.GetWebProxy();


### PR DESCRIPTION
… the S3Client also applies to the internal KMS client

<!--- Provide a general summary of your changes in the Title above -->

## Description
Set KMS Client config timeout from the S3 client config so that the setting applies to both the S3 client and internal KMS client.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows the S3 timeout to apply to the internal KMS client. E.g. lowering the S3 client timeout to abandon calls over say, 10 seconds is not possible because the internal KMS client will always call for 100 seconds as the default HttpClient timeout.
<!--- If it fixes an open [issue][issues], please link to the issue here -->
https://github.com/aws/amazon-s3-encryption-client-dotnet/issues/31
## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement