### PR TITLE
use instr. cekalgorithm in place of MaterialsDescription prop

### DIFF
--- a/src/Internal/SetupDecryptionHandler.cs
+++ b/src/Internal/SetupDecryptionHandler.cs
@@ -423,10 +423,10 @@ namespace Amazon.Extensions.S3.Encryption.Internal
             if (decryptedEnvelopeKeyKMS != null)
             {
                 if (getObjectResponse.Metadata[EncryptionUtils.XAmzCekAlg] != null
-                    && instructions.MaterialsDescription.ContainsKey(EncryptionUtils.XAmzEncryptionContextCekAlg))
+                    && instructions.CekAlgorithm != null)
                 {
                     if (EncryptionUtils.XAmzAesGcmCekAlgValue.Equals(getObjectResponse.Metadata[EncryptionUtils.XAmzCekAlg])
-                        && EncryptionUtils.XAmzAesGcmCekAlgValue.Equals(instructions.MaterialsDescription[EncryptionUtils.XAmzEncryptionContextCekAlg]))
+                        && EncryptionUtils.XAmzAesGcmCekAlgValue.Equals(instructions.CekAlgorithm))
                     {
                         // Decrypt the object with V2 instruction
                         EncryptionUtils.DecryptObjectUsingInstructionsV2(getObjectResponse, instructions);


### PR DESCRIPTION
## Description
Replaces the referenced algorithm (instructions.MaterialsDescription[EncryptionUtils.XAmzEncryptionContextCekAlg]), which evaluates to null with the algortithm referenced as a property on instructions (instructions.cekAlgorithm) which is populated with the expected algorithm earlier in the call stack. 

## Motivation and Context
Fixes issue #26 where the content encryption algorithm used at encryption time does not match the algorithm stored for decryption time. The end-result is users of the library will be able to client side decryption library in cases such as my use case, where we have SES store emails as encrypted s3 objects and wish to decrypt those objects in our code.

## Testing
I first used JetBrains dotPeek to decompile a version I could test against my particular use case. Once I made the appropriate change in that local version, I took the main changes from that fix and updated this repo. Once updated, I tested the code change by executing the code locally. I verified that this code is only utilized inside s3 object decryption, so it wouldn't impact other functionality outside of that scope.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [x ] All new and existing tests passed

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement