### PR TITLE
Bug fix: remove unnecessary materialDescription validation

### DIFF
--- a/src/Internal/SetupDecryptionHandler.cs
+++ b/src/Internal/SetupDecryptionHandler.cs
@@ -422,20 +422,10 @@ namespace Amazon.Extensions.S3.Encryption.Internal
 
             if (decryptedEnvelopeKeyKMS != null)
             {
-                if (getObjectResponse.Metadata[EncryptionUtils.XAmzCekAlg] != null
-                    && instructions.MaterialsDescription.ContainsKey(EncryptionUtils.XAmzEncryptionContextCekAlg))
+                if (EncryptionUtils.XAmzAesGcmCekAlgValue.Equals(instructions.CekAlgorithm))
                 {
-                    if (EncryptionUtils.XAmzAesGcmCekAlgValue.Equals(getObjectResponse.Metadata[EncryptionUtils.XAmzCekAlg])
-                        && EncryptionUtils.XAmzAesGcmCekAlgValue.Equals(instructions.MaterialsDescription[EncryptionUtils.XAmzEncryptionContextCekAlg]))
-                    {
-                        // Decrypt the object with V2 instruction
-                        EncryptionUtils.DecryptObjectUsingInstructionsV2(getObjectResponse, instructions);
-                    }
-                    else
-                    {
-                        throw new AmazonCryptoException($"The content encryption algorithm used at encryption time does not match the algorithm stored for decryption time." +
-                                                        " The object may be altered or corrupted.");
-                    }
+                    // Decrypt the object with V2 instruction
+                    EncryptionUtils.DecryptObjectUsingInstructionsV2(getObjectResponse, instructions);
                 }
                 else if (EncryptionUtils.XAmzAesCbcPaddingCekAlgValue.Equals(instructions.CekAlgorithm))
                 {


### PR DESCRIPTION
Bug fix: remove unnecessary materialDescription validation when decrypting S3 object using metadata

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This commit will resolve the error that occurs when encrypting an email through AWS SES using KMS, then decrypting it using this library. We are checking if materialDescription metadata field contains a certain value before we decrypt it. However, we don't need this validation because we are validating another field as well. A problem occurs when we use AWS SES encryption rule set because it doesn't populate this metadata field to the S3 encrypted object. Note that other SDK languages already support SES decryption though KMS; hence why, this is a bug.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --> Decrypting an email, which was encrypted using AWS SES with KMS, fails because we are validating a metadata field that isn't populated by AWS SES
<!--- If it fixes an open [issue][issues], please link to the issue here --> https://github.com/aws/amazon-s3-encryption-client-dotnet/issues/26

## Testing
<!--- Please describe in detail how you tested your changes --> Ran all unit and integration tests locally and they all succeeded


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X ] My code follows the code style of this project
- [X] I have read the **README** document
- [X] I have added tests to cover my changes (they already exist)
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement