### PR TITLE
Bug fix: Handle S3 decryption using AWS SES

### DIFF
--- a/src/Amazon.Extensions.S3.Encryption.csproj
+++ b/src/Amazon.Extensions.S3.Encryption.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net35;net45;netstandard2.0;netcoreapp3.1</TargetFrameworks>
-        <Version>2.0.4</Version>
+        <Version>2.0.5</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Amazon.Extensions.S3.Encryption</PackageId>
         <Title>Amazon S3 Encryption Client for .NET</Title>
@@ -15,8 +15,8 @@
         <PackageIcon>icon.png</PackageIcon>
         <RepositoryUrl>https://github.com/aws/amazon-s3-encryption-client-dotnet/</RepositoryUrl>
         <Company>Amazon Web Services</Company>
-        <AssemblyVersion>2.0.4</AssemblyVersion>
-        <FileVersion>2.0.4</FileVersion>
+        <AssemblyVersion>2.0.5</AssemblyVersion>
+        <FileVersion>2.0.5</FileVersion>
 
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>

--- a/src/EncryptionUtils.cs
+++ b/src/EncryptionUtils.cs
@@ -24,6 +24,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using Amazon.KeyManagementService;
 using Amazon.Runtime.SharedInterfaces;
+using Amazon.Extensions.S3.Encryption.Util;
 
 namespace Amazon.Extensions.S3.Encryption
 {
@@ -200,7 +201,7 @@ namespace Amazon.Extensions.S3.Encryption
         }
 #endregion
 
-        #region StreamDecrption
+        #region StreamDecryption
 
         /// <summary>
         /// Updates object where the object
@@ -225,6 +226,20 @@ namespace Amazon.Extensions.S3.Encryption
             return aesDecryptStream;
         }
 
+        /// <summary>
+        /// Updates object where the object
+        /// input stream contains the decrypted contents.
+        /// </summary>
+        /// <param name="response">
+        /// The getObject response whose contents are to be decrypted.
+        /// </param>
+        /// <param name="instructions">
+        /// The instruction that will be used to encrypt the object data.
+        /// </param>
+        internal static void DecryptObjectUsingInstructionsGcm(GetObjectResponse response, EncryptionInstructions instructions)
+        {
+            response.ResponseStream = new AesGcmDecryptStream(response.ResponseStream, instructions.EnvelopeKey, instructions.InitializationVector, DefaultTagBitsLength);
+        }
 
         #endregion
 

--- a/src/EncryptionUtilsV2.cs
+++ b/src/EncryptionUtilsV2.cs
@@ -23,7 +23,6 @@ using Amazon.Extensions.S3.Encryption.Primitives;
 using Amazon.Extensions.S3.Encryption.Util;
 using Amazon.KeyManagementService;
 using Amazon.Runtime;
-using Amazon.Runtime.SharedInterfaces;
 using Amazon.S3.Model;
 using ThirdParty.Json.LitJson;
 
@@ -325,21 +324,6 @@ namespace Amazon.Extensions.S3.Encryption
             };
             instructionFileRequest.Metadata.Add(XAmzCryptoInstrFile, "");
             return instructionFileRequest;
-        }
-
-        /// <summary>
-        /// Updates object where the object
-        /// input stream contains the decrypted contents.
-        /// </summary>
-        /// <param name="response">
-        /// The getObject response whose contents are to be decrypted.
-        /// </param>
-        /// <param name="instructions">
-        /// The instruction that will be used to encrypt the object data.
-        /// </param>
-        internal static void DecryptObjectUsingInstructionsV2(GetObjectResponse response, EncryptionInstructions instructions)
-        {
-            response.ResponseStream = new AesGcmDecryptStream(response.ResponseStream, instructions.EnvelopeKey, instructions.InitializationVector, DefaultTagBitsLength);
         }
 
         /// <summary>

--- a/test/UnitTests/AesGcmDecryptUsingMetadata.cs
+++ b/test/UnitTests/AesGcmDecryptUsingMetadata.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using System.Text;
+using Amazon.Extensions.S3.Encryption.Internal;
+using Amazon.Extensions.S3.Encryption.Util;
+using Amazon.S3.Model;
+using Moq;
+using System.IO;
+using Xunit.Extensions;
+using Xunit;
+
+namespace Amazon.Extensions.S3.Encryption.UnitTests
+{
+    public class AesGcmDecryptUsingMetadata
+    {
+        /* Metadata extracted from an encrypted S3 object sample using AWS SES */
+        private static readonly byte[] DecryptedEnvelopeKeyKMS = { 52, 5, 73, 94, 237, 126, 210, 67, 26, 221, 182, 9, 236, 225, 197, 184, 147, 117, 60, 119, 141, 201, 21, 19, 2, 178, 62, 22, 120, 102, 137, 45 };
+        private static readonly string[] MetadataDictionaryKeys = { "x-amz-meta-x-amz-tag-len", "x-amz-meta-x-amz-unencrypted-content-length", "x-amz-meta-x-amz-wrap-alg",
+                "x-amz-meta-x-amz-matdesc" , "x-amz-meta-x-amz-key-v2" , "x-amz-meta-x-amz-cek-alg", "x-amz-meta-x-amz-iv" };
+        private static readonly string[] MetadataDictionaryValues = { "128", "3946", "kms", "{\"aws:ses:message-id\":\"lhne4tbq09c867b1ko1f3ho4fqfidcatruo26781\",\"aws:ses:rule-name\":\"encrypt-to-s3\",\"aws:ses:source-account\":\"{AWS_ACCOUNT_ID}\",\"kms_cmk_id\":\"arn:aws:kms:{AWS_ACCOUNT_ID}:{AWS_ACCOUNT_ID}:alias/aws/ses\"}",
+            "AQIDAHgN94fUlYO17HEeDorBZENwiXuQ3swljPjtZVKT/lVftAHJVBJhXNH02aAWuPsxxBo5AAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQMvq8jOYujNpL+coHxAgEQgDsRyJ3hFidKl5hw208WxBcNPCnlFmHyQ36HEewuORCoqGIor4uuhe3mcmVdGv2e5qob3Ju/C4hC3Ekpvg==",
+            "AES/GCM/NoPadding", "NUhrJ+0LoGyof/dj" };
+        private static readonly string KmsKeyId = "730b1bf4-9483-4834-b75e-8174ad092192";
+
+        [Theory]
+        [InlineData(SecurityProfile.V2)]
+        public void DecryptWithoutEncryptionContext_SecurityProfileV2(SecurityProfile securityProfile)
+        {
+            var encryptionMaterialsV2 = new EncryptionMaterialsV2(KmsKeyId, Primitives.KmsType.KmsContext, new Dictionary<string, string>());
+            var amazonS3EncryptionClientV2 = new AmazonS3EncryptionClientV2(new AmazonS3CryptoConfigurationV2(securityProfile), encryptionMaterialsV2);
+            var mockSetupDecryptionHandlerV2 = new Mock<SetupDecryptionHandlerV2>(amazonS3EncryptionClientV2);
+
+            mockSetupDecryptionHandlerV2.CallBase = true;
+
+            var mockObjectResponse = new Mock<GetObjectResponse>();
+            for (int i = 0; i < MetadataDictionaryKeys.Length; i++)
+            {
+                mockObjectResponse.Object.Metadata.Add(MetadataDictionaryKeys[i], MetadataDictionaryValues[i]);
+            }
+
+            Assert.Throws<AmazonCryptoException>(() =>
+            {
+                Utils.RunInstanceMethod(typeof(SetupDecryptionHandlerV2), "DecryptObjectUsingMetadata", mockSetupDecryptionHandlerV2.Object, new object[] { mockObjectResponse.Object, DecryptedEnvelopeKeyKMS });
+            });
+        }
+
+        [Theory]
+        [InlineData(SecurityProfile.V2AndLegacy)]
+        public void DecryptWithoutEncryptionContext_V2AndLegacy(SecurityProfile securityProfile)
+        {
+            var encryptionMaterialsV2 = new EncryptionMaterialsV2(KmsKeyId, Primitives.KmsType.KmsContext, new Dictionary<string, string>());
+            var amazonS3EncryptionClientV2 = new AmazonS3EncryptionClientV2(new AmazonS3CryptoConfigurationV2(securityProfile), encryptionMaterialsV2);
+            var mockSetupDecryptionHandlerV2 = new Mock<SetupDecryptionHandlerV2>(amazonS3EncryptionClientV2);
+
+            mockSetupDecryptionHandlerV2.CallBase = true;
+
+            var mockObjectResponse = new Mock<GetObjectResponse>();
+            mockObjectResponse.Object.ResponseStream = new MemoryStream(Encoding.UTF8.GetBytes(""));
+            for (int i = 0; i < MetadataDictionaryKeys.Length; i++)
+            {
+                mockObjectResponse.Object.Metadata.Add(MetadataDictionaryKeys[i], MetadataDictionaryValues[i]);
+            }
+
+            Utils.RunInstanceMethod(typeof(SetupDecryptionHandlerV2), "DecryptObjectUsingMetadata", mockSetupDecryptionHandlerV2.Object, new object[] { mockObjectResponse.Object, DecryptedEnvelopeKeyKMS });
+
+            Assert.True(mockObjectResponse.Object.ResponseStream.GetType() == typeof(AesGcmDecryptStream));
+        }
+
+    }
+}
+

--- a/test/UnitTests/Amazon.Extensions.S3.Encryption.UnitTests.csproj
+++ b/test/UnitTests/Amazon.Extensions.S3.Encryption.UnitTests.csproj
@@ -3,7 +3,7 @@
         <TargetFrameworks>net35;net45;netcoreapp2.1</TargetFrameworks>
         <DefineConstants Condition="'$(TargetFramework)' == 'net35'">$(DefineConstants);DEBUG;TRACE;BCL;BCL35;AWS_APM_API</DefineConstants>
         <DefineConstants Condition="'$(TargetFramework)' == 'net45'">$(DefineConstants);DEBUG;TRACE;BCL;BCL45;ASYNC_AWAIT;</DefineConstants>
-        <DefineConstants Condition="'$(TargetFramework)' == 'netcoreapp2.0'">$(DefineConstants);NETSTANDARD;AWS_ASYNC_API</DefineConstants>
+        <DefineConstants Condition="'$(TargetFramework)' == 'netcoreapp2.1'">$(DefineConstants);NETSTANDARD;AWS_ASYNC_API</DefineConstants>
         <IsPackable>false</IsPackable>
 
         <!-- workaround per https://github.com/Microsoft/msbuild/issues/1333 -->
@@ -21,6 +21,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+        <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.1'" Include="Moq" Version="4.18.4" />
+        <PackageReference Condition="'$(TargetFramework)' == 'net35' Or '$(TargetFramework)' == 'net45'" Include="Moq" Version="4.0.10827" />
         <PackageReference Condition="'$(TargetFramework)' == 'net35' Or '$(TargetFramework)' == 'net45'" Include="xunit.extensions" Version="1.9.2" />
         <PackageReference Condition="'$(TargetFramework)' == 'netcoreapp2.1'" Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/test/UnitTests/Utils.cs
+++ b/test/UnitTests/Utils.cs
@@ -14,6 +14,7 @@
  */
 
 using System;
+using System.Reflection;
 
 namespace Amazon.Extensions.S3.Encryption.UnitTests
 {
@@ -43,6 +44,33 @@ namespace Amazon.Extensions.S3.Encryption.UnitTests
                 hexString += number.ToString("X").PadLeft(2, '0');  
             }
             return hexString;  
+        }
+
+        // Reflection is used to test inaccessible methods
+        public static object RunInstanceMethod(Type type, string strMethod, object objInstance, object[] objParams)
+        {
+            BindingFlags flags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+            return RunMethod(type, strMethod, objInstance, objParams, flags);
+        }
+
+        private static object RunMethod(Type type, string strMethod, object objInstance, object[] objParams, BindingFlags flags)
+        {
+            MethodInfo methodInfo;
+            try
+            {
+                methodInfo = type.GetMethod(strMethod, flags);
+                if (methodInfo == null)
+                {
+                    throw new ArgumentException("There is no method '" + strMethod + "' for type '" + type.ToString() + "'.");
+                }
+
+                object objReturn = methodInfo.Invoke(objInstance, objParams);
+                return objReturn;
+            }
+            catch (Exception e)
+            {
+                throw e.InnerException;
+            }
         }
     }
 }


### PR DESCRIPTION
Bug fix: remove unnecessary materialDescription validation when decrypting S3 object using metadata

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This commit will resolve the error that occurs when encrypting an email through AWS SES using KMS, then decrypting it using this library. We are checking if materialDescription metadata field contains a certain value before we decrypt it.  A problem occurs when we use AWS SES encryption rule set because it doesn't populate this metadata field to the S3 encrypted object. We added another if statement to handle this missing use case. Note that other SDK languages already support SES decryption though KMS; hence why this is a bug. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --> Decrypting an email, which was encrypted using AWS SES with KMS, fails because we are validating a metadata field that isn't populated by AWS SES.
<!--- If it fixes an open [issue][issues], please link to the issue here --> https://github.com/aws/amazon-s3-encryption-client-dotnet/issues/26

## Testing
<!--- Please describe in detail how you tested your changes --> Ran all unit and integration tests locally and they all succeeded


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project
- [X] I have read the **README** document
- [X] I have added tests to cover my changes
- [X] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [X] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement