### PR TITLE
Fix issue #54 with stream being unintentionally closed before all parts are uploaded.

### DIFF
--- a/src/Amazon.Extensions.S3.Encryption.csproj
+++ b/src/Amazon.Extensions.S3.Encryption.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net35;net45;netstandard2.0;netcoreapp3.1</TargetFrameworks>
-        <Version>2.1.1</Version>
+        <Version>2.1.2</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>Amazon.Extensions.S3.Encryption</PackageId>
         <Title>Amazon S3 Encryption Client for .NET</Title>
@@ -15,8 +15,8 @@
         <PackageIcon>icon.png</PackageIcon>
         <RepositoryUrl>https://github.com/aws/amazon-s3-encryption-client-dotnet/</RepositoryUrl>
         <Company>Amazon Web Services</Company>
-        <AssemblyVersion>2.1.1</AssemblyVersion>
-        <FileVersion>2.1.1</FileVersion>
+        <AssemblyVersion>2.1.2</AssemblyVersion>
+        <FileVersion>2.1.2</FileVersion>
 
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>

--- a/src/Internal/SetupDecryptionHandlerV1.cs
+++ b/src/Internal/SetupDecryptionHandlerV1.cs
@@ -22,6 +22,7 @@ using Amazon.KeyManagementService.Model;
 using Amazon.Runtime.Internal.Util;
 using Amazon.S3;
 using ThirdParty.Json.LitJson;
+using Amazon.Extensions.S3.Encryption.Util;
 
 namespace Amazon.Extensions.S3.Encryption.Internal
 {
@@ -168,7 +169,7 @@ namespace Amazon.Extensions.S3.Encryption.Internal
             {
                 object stream = null;
 
-                if (!((Amazon.Runtime.Internal.IAmazonWebServiceRequest) uploadPartRequest).RequestState.TryGetValue(AmazonS3EncryptionClient.S3CryptoStream, out stream))
+                if (!((Amazon.Runtime.Internal.IAmazonWebServiceRequest) uploadPartRequest).RequestState.TryGetValue(Constants.S3CryptoStreamRequestState, out stream))
                     throw new AmazonS3Exception("Cannot retrieve S3 crypto stream from request state, hence cannot get Initialization vector for next uploadPart ");
 
                 var encryptionStream = stream as AESEncryptionUploadPartStream;

--- a/src/Internal/SetupDecryptionHandlerV2.cs
+++ b/src/Internal/SetupDecryptionHandlerV2.cs
@@ -135,7 +135,7 @@ namespace Amazon.Extensions.S3.Encryption.Internal
             {
                 object stream = null;
 
-                if (!((IAmazonWebServiceRequest) uploadPartRequest).RequestState.TryGetValue(AmazonS3EncryptionClient.S3CryptoStream, out stream))
+                if (!((IAmazonWebServiceRequest) uploadPartRequest).RequestState.TryGetValue(Constants.S3CryptoStreamRequestState, out stream))
                     throw new AmazonS3Exception("Cannot retrieve S3 crypto stream from request state, hence cannot get Initialization vector for next uploadPart ");
 
                 var encryptionStream = stream as AESEncryptionUploadPartStream;

--- a/src/Internal/SetupEncryptionHandlerV1.cs
+++ b/src/Internal/SetupEncryptionHandlerV1.cs
@@ -15,6 +15,7 @@
 
  using Amazon.Runtime;
  using Amazon.S3.Model;
+using Amazon.Extensions.S3.Encryption.Util;
 
  namespace Amazon.Extensions.S3.Encryption.Internal
 {
@@ -153,7 +154,7 @@
                 request.InputStream = EncryptionUtils.EncryptRequestUsingInstruction(request.InputStream, instructions);
                 contextForEncryption.IsFinalPart = true;
             }
-            ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)request).RequestState.Add(AmazonS3EncryptionClient.S3CryptoStream, request.InputStream);
+            ((Amazon.Runtime.Internal.IAmazonWebServiceRequest)request).RequestState.Add(Constants.S3CryptoStreamRequestState, request.InputStream);
         }
     }
 }

--- a/src/Util/AesGcmEncryptStream.cs
+++ b/src/Util/AesGcmEncryptStream.cs
@@ -148,5 +148,30 @@ namespace Amazon.Extensions.S3.Encryption.Util
             }
         }
 #endif
+
+        /// <summary>
+        /// If set to true the Close and Dispose methods will be a noop. This is necessary in multipart
+        /// upload scenarios when we want the SDK to only dispose the stream on the last part.
+        /// </summary>
+        internal bool DisableDispose { get; set; }
+
+#if !NETSTANDARD
+        /// <inheritdoc/>
+        public override void Close()
+        {
+            if (!DisableDispose)
+            {
+                base.Close();
+            }
+        }
+#else
+        protected override void Dispose(bool disposing)
+        {
+            if (!DisableDispose)
+            {
+                base.Dispose(disposing);
+            }
+        }
+#endif
     }
 }

--- a/src/Util/Constants.cs
+++ b/src/Util/Constants.cs
@@ -1,0 +1,21 @@
+﻿/*
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* 
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+* 
+*  http://aws.amazon.com/apache2.0
+* 
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+namespace Amazon.Extensions.S3.Encryption.Util
+{
+    internal class Constants
+    {
+        internal const string S3CryptoStreamRequestState = "S3-Crypto-Stream";
+    }
+}

--- a/test/IntegrationTests/_bcl/Utilities/EncryptionTestsUtils.cs
+++ b/test/IntegrationTests/_bcl/Utilities/EncryptionTestsUtils.cs
@@ -42,7 +42,7 @@ namespace Amazon.Extensions.S3.Encryption.IntegrationTests.Utilities
 
         public static void TestTransferUtility(IAmazonS3 s3EncryptionClient, IAmazonS3 s3DecryptionClient, string bucketName)
         {
-            var directory = TransferUtilityTests.CreateTestDirectory(10 * TransferUtilityTests.KILO_SIZE);
+            var directory = TransferUtilityTests.CreateTestDirectory(30 * MegaByteSize);
             var keyPrefix = directory.Name;
             var directoryPath = directory.FullName;
 


### PR DESCRIPTION
## Description
When doing a multipart upload the underlying `AesGcmEncryptStream` for the V2 client. This allows the encryption state to persist across part uploads. The SDK when seeing the the `InputStream` was created in behalf of the user because they set the `FilePath` property would close the stream after the request was complete. This had the side affect of closing the shared `AesGcmEncryptStream` causing the second part upload to fail to upload.

To accommodate the SDK closing the stream I added a `DisableDispose` property on `AesGcmEncryptStream` that if set to true would cause the dispose/close on the `AesGcmEncryptStream` to be a noop. The encryption client would set `DisableDispose` to true for all parts except the last part.

By not having the SDK close the stream that also meant if an exception occurred anything besides the last part the stream would not be closed. In the V2 encryption pipeline handler I added the `HandleException` to be called whenever there were request pipeline exception and force the `AesGcmEncryptStream` stream to be closed even if the `DisableDispose` property was true.

Unrelated to the issue I also removed the references to a constant from the obsolete S3 encryption client in the AWSSDK.S3 package. Since we are removing that client in V4 seemed good to remove that reference while I was here.


## Motivation and Context
https://github.com/aws/amazon-s3-encryption-client-dotnet/issues/54

## Testing
Change the existing tests to use large files forcing multipart uploads in the TransferUtility directory upload. I also forced exceptions to confirm the `HandleException` in the pipeline handler was closing the stream.
