### PR TITLE
Make SDK V4 preview version trimmable

### DIFF
--- a/.autover/changes/A37D7270-9F43-4933-9FAC-BFBBBC4670CB.json
+++ b/.autover/changes/A37D7270-9F43-4933-9FAC-BFBBBC4670CB.json
@@ -1,0 +1,12 @@
+{
+	"Projects": [
+    {
+      "Name": "Amazon.Extensions.S3.Encryption",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Mark the assembly trimmable",
+        "Enable Source Link"
+      ]
+    }
+  ]	
+}

--- a/src/Amazon.Extensions.S3.Encryption.csproj
+++ b/src/Amazon.Extensions.S3.Encryption.csproj
@@ -19,8 +19,17 @@
         <AssemblyOriginatorKeyFile>..\public.snk</AssemblyOriginatorKeyFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
-    
+
+    <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+        <IsTrimmable>true</IsTrimmable>
+    </PropertyGroup>
+
     <PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
         <AssemblyVersion>3.0.0</AssemblyVersion>
     </PropertyGroup>
@@ -36,6 +45,7 @@
         <PackageReference Include="AWSSDK.S3" Version="4.0.0-preview.4" />
         <PackageReference Include="AWSSDK.KeyManagementService" Version="4.0.0-preview.4" />
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>
 
     <!-- TODO: The dependency on Microsoft.Bcl.AsyncInterfaces should be removed once the issue causing it to be needed in the .NET SDK is fixed  -->

--- a/src/Internal/SetupDecryptionHandlerV1.cs
+++ b/src/Internal/SetupDecryptionHandlerV1.cs
@@ -13,15 +13,12 @@
  * permissions and limitations under the License.
  */
 
-using System;
 using System.Collections.Generic;
-using Amazon.Runtime;
-using Amazon.S3.Model;
 using System.IO;
+using Amazon.S3;
+using Amazon.S3.Model;
 using Amazon.KeyManagementService.Model;
 using Amazon.Runtime.Internal.Util;
-using Amazon.S3;
-using ThirdParty.Json.LitJson;
 using Amazon.Extensions.S3.Encryption.Util;
 
 namespace Amazon.Extensions.S3.Encryption.Internal
@@ -55,27 +52,17 @@ namespace Amazon.Extensions.S3.Encryption.Internal
             }
             else
             {
-                JsonData materialDescriptionJsonData;
+                Dictionary<string,string> materialDescriptionJsonData;
                 try
                 {
-                    materialDescriptionJsonData = JsonMapper.ToObject(materialDescriptionJsonString);
+                    materialDescriptionJsonData = JsonUtils.ToDictionary(materialDescriptionJsonString);
                 }
-                catch (JsonException e)
+                catch (InvalidDataException e)
                 {
                     throw new InvalidDataException($"{KMSKeyIDMetadataMessage} The key '{EncryptionUtils.XAmzMatDesc}' does not contain valid JSON.", e);
                 }
 
-                JsonData kmsKeyIDJsonData;
-                try
-                {
-                    kmsKeyIDJsonData = materialDescriptionJsonData[EncryptionUtils.KMSCmkIDKey];
-                }
-                catch (JsonException e)
-                {
-                    throw new InvalidDataException($"{KMSKeyIDMetadataMessage} The key '{EncryptionUtils.KMSCmkIDKey}' is does not contain valid JSON.", e);
-                }
-
-                if (kmsKeyIDJsonData == null)
+                if (!materialDescriptionJsonData.TryGetValue(EncryptionUtils.KMSCmkIDKey, out var kmsKeyIDJsonData))
                 {
                     throw new InvalidDataException($"{KMSKeyIDMetadataMessage} The key '{kmsKeyIDJsonData}' is missing from the material description.");
                 }

--- a/src/Util/JsonUtils.cs
+++ b/src/Util/JsonUtils.cs
@@ -1,0 +1,83 @@
+﻿/*
+* Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+* 
+* Licensed under the Apache License, Version 2.0 (the "License").
+* You may not use this file except in compliance with the License.
+* A copy of the License is located at
+* 
+*  http://aws.amazon.com/apache2.0
+* 
+* or in the "license" file accompanying this file. This file is distributed
+* on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+* express or implied. See the License for the specific language governing
+* permissions and limitations under the License.
+*/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+
+namespace Amazon.Extensions.S3.Encryption.Util
+{
+    internal static class JsonUtils
+    {
+
+        internal static string ToJson(Dictionary<string, string> keyValuePairs)
+        {
+            var stream = new MemoryStream();
+            using (var writer = new Utf8JsonWriter(stream))
+            {
+                writer.WriteStartObject();
+                foreach (var kvp in keyValuePairs)
+                {
+                    writer.WriteString(kvp.Key, kvp.Value);
+                }
+                writer.WriteEndObject();
+            }
+
+            stream.Position = 0;
+            return new StreamReader(stream).ReadToEnd();
+        }
+
+        internal static Dictionary<string,string> ToDictionary(string json)
+        {
+            var dictionary = new Dictionary<string,string>();
+            byte[] bytes = Encoding.UTF8.GetBytes(json);
+            var reader = new Utf8JsonReader(new ReadOnlySpan<byte>(bytes));
+
+            reader.Read();
+            if (reader.TokenType != JsonTokenType.StartObject)
+                throw new InvalidDataException("Key value pair JSON must start with an object.");
+
+            // Read to the first property
+            reader.Read();
+
+            while(reader.TokenType != JsonTokenType.EndObject)
+            {
+                if (reader.TokenType != JsonTokenType.PropertyName)
+                    throw new InvalidDataException("Key value pair JSON missing property name.");
+
+                var key = reader.GetString();
+
+                reader.Read();
+                if (reader.TokenType != JsonTokenType.String)
+                    throw new InvalidDataException("Key value pair JSON must only have string values.");
+
+                var value = reader.GetString();
+
+                // To make the existence checks easier in this library don't include null values.
+                // That way rest of the library just needs to do ContainsKey check.
+                if (value != null)
+                {
+                    dictionary[key] = value;
+                }
+
+                // Move to the next property or end of object
+                reader.Read();
+            }
+
+            return dictionary;
+        }
+    }
+}


### PR DESCRIPTION
## Description
Make the V4 SDK preview version trimmable as well as add the metadata for sourcelink.

In order to make the library trimmable I replaced the usage of LitJson with System.Text.Json. This JSON used in the library is always a simple single object JSON of string to string pairs. I created a couple utility methods for converting back and forth from JSON to Dictionary<string, string>.

## Testing
Ran the unit and integ tests and all still pass. I manually verified the JSON being produced is the same between LitJson and System.Text.Json and the only difference I saw when writing JSON with System.Text.Json it does more escaping for example escaping the `+`. I verified LitJson handled the escaping during reading. So if a user writes an object to S3 with this version and old version of the package using LitJson would still be able to read it.
