### PR TITLE
chore: Update .NET SDK dependencies to v4.0.0-preview.8

### DIFF
--- a/.autover/changes/e9eef7fe-b2d6-4673-937b-830054025837.json
+++ b/.autover/changes/e9eef7fe-b2d6-4673-937b-830054025837.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Extensions.S3.Encryption",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update .NET SDK dependencies to v4.0.0-preview.8"
+      ]
+    }
+  ]
+}

--- a/src/Amazon.Extensions.S3.Encryption.csproj
+++ b/src/Amazon.Extensions.S3.Encryption.csproj
@@ -41,9 +41,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.Core" Version="4.0.0-preview.4" />
-        <PackageReference Include="AWSSDK.S3" Version="4.0.0-preview.4" />
-        <PackageReference Include="AWSSDK.KeyManagementService" Version="4.0.0-preview.4" />
+        <PackageReference Include="AWSSDK.Core" Version="4.0.0-preview.8" />
+        <PackageReference Include="AWSSDK.S3" Version="4.0.0-preview.8" />
+        <PackageReference Include="AWSSDK.KeyManagementService" Version="4.0.0-preview.8" />
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.4.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>

--- a/src/EncryptionUtilsV2.cs
+++ b/src/EncryptionUtilsV2.cs
@@ -112,19 +112,12 @@ namespace Amazon.Extensions.S3.Encryption
         /// <param name="instructions">
         /// The instruction that will be used to encrypt the object data.
         /// </param>
-        /// <param name="shouldUseCachingStream">
-        /// Flag indicating if the caching stream should be used or not.
-        /// </param>
         /// <returns>
         /// Encrypted stream, i.e input stream wrapped into encrypted stream
         /// </returns>
-        internal static Stream EncryptRequestUsingInstructionV2(Stream toBeEncrypted, EncryptionInstructions instructions, bool shouldUseCachingStream)
+        internal static Stream EncryptRequestUsingInstructionV2(Stream toBeEncrypted, EncryptionInstructions instructions)
         {
-            Stream gcmEncryptStream = (shouldUseCachingStream ? 
-                                        new AesGcmEncryptCachingStream(toBeEncrypted, instructions.EnvelopeKey, instructions.InitializationVector, DefaultTagBitsLength)
-                                        : new AesGcmEncryptStream(toBeEncrypted, instructions.EnvelopeKey, instructions.InitializationVector, DefaultTagBitsLength)
-                                       );
-            return gcmEncryptStream;
+            return new AesGcmEncryptCachingStream(toBeEncrypted, instructions.EnvelopeKey, instructions.InitializationVector, DefaultTagBitsLength);
         }
 
         /// <summary>

--- a/src/Internal/SetupEncryptionHandlerV2.cs
+++ b/src/Internal/SetupEncryptionHandlerV2.cs
@@ -119,7 +119,7 @@ namespace Amazon.Extensions.S3.Encryption.Internal
             EncryptionUtils.AddUnencryptedContentLengthToMetadata(putObjectRequest);
 
             // Encrypt the object data with the instruction
-            putObjectRequest.InputStream = EncryptionUtils.EncryptRequestUsingInstructionV2(putObjectRequest.InputStream, instructions, putObjectRequest.CalculateContentMD5Header);
+            putObjectRequest.InputStream = EncryptionUtils.EncryptRequestUsingInstructionV2(putObjectRequest.InputStream, instructions);
 
             // Create request for uploading instruction file 
             PutObjectRequest instructionFileRequest = EncryptionUtils.CreateInstructionFileRequestV2(putObjectRequest, instructions);
@@ -150,7 +150,7 @@ namespace Amazon.Extensions.S3.Encryption.Internal
             EncryptionUtils.AddUnencryptedContentLengthToMetadata(putObjectRequest);
 
             // Encrypt the object data with the instruction
-            putObjectRequest.InputStream = EncryptionUtils.EncryptRequestUsingInstructionV2(putObjectRequest.InputStream, instructions, putObjectRequest.CalculateContentMD5Header);
+            putObjectRequest.InputStream = EncryptionUtils.EncryptRequestUsingInstructionV2(putObjectRequest.InputStream, instructions);
 
             // Update the metadata
             EncryptionUtils.UpdateMetadataWithEncryptionInstructionsV2(putObjectRequest, instructions, EncryptionClient);

--- a/test/IntegrationTests/Amazon.Extensions.S3.Encryption.IntegrationTests.NetFramework.csproj
+++ b/test/IntegrationTests/Amazon.Extensions.S3.Encryption.IntegrationTests.NetFramework.csproj
@@ -11,9 +11,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.0-preview.2" />
-        <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.0-preview.2" />
-        <PackageReference Include="AWSSDK.ResourceGroupsTaggingAPI" Version="4.0.0-preview.2" />
+        <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.0-preview.8" />
+        <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.0-preview.8" />
+        <PackageReference Include="AWSSDK.ResourceGroupsTaggingAPI" Version="4.0.0-preview.8" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
         <PackageReference Include="xunit" Version="1.9.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/test/IntegrationTests/Amazon.Extensions.S3.Encryption.IntegrationTests.NetStandard.csproj
+++ b/test/IntegrationTests/Amazon.Extensions.S3.Encryption.IntegrationTests.NetStandard.csproj
@@ -12,9 +12,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.0-preview.2" />
-        <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.0-preview.2" />
-        <PackageReference Include="AWSSDK.ResourceGroupsTaggingAPI" Version="4.0.0-preview.2" />
+        <PackageReference Include="AWSSDK.SecurityToken" Version="4.0.0-preview.8" />
+        <PackageReference Include="AWSSDK.SimpleNotificationService" Version="4.0.0-preview.8" />
+        <PackageReference Include="AWSSDK.ResourceGroupsTaggingAPI" Version="4.0.0-preview.8" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/test/IntegrationTests/_bcl/Utilities/EncryptionTestsUtils.cs
+++ b/test/IntegrationTests/_bcl/Utilities/EncryptionTestsUtils.cs
@@ -66,7 +66,6 @@ namespace Amazon.Extensions.S3.Encryption.IntegrationTests.Utilities
             using (var transferUtility = new TransferUtility(s3EncryptionClient))
             {
                 var uploadRequest = CreateUploadDirRequest(directoryPath, keyPrefix, bucketName);
-                uploadRequest.CalculateContentMD5Header = true;
                 transferUtility.UploadDirectory(uploadRequest);
 
                 var newDir = TransferUtilityTests.GenerateDirectoryPath();
@@ -259,8 +258,7 @@ namespace Amazon.Extensions.S3.Encryption.IntegrationTests.Utilities
                     UploadId = initResponse.UploadId,
                     PartNumber = 1,
                     PartSize = 5 * MegaByteSize,
-                    InputStream = inputStream,
-                    CalculateContentMD5Header = true
+                    InputStream = inputStream
                 };
 
                 var up1Response = s3EncryptionClient.UploadPart(uploadRequest);
@@ -273,8 +271,7 @@ namespace Amazon.Extensions.S3.Encryption.IntegrationTests.Utilities
                     UploadId = initResponse.UploadId,
                     PartNumber = 2,
                     PartSize = 5 * MegaByteSize,
-                    InputStream = inputStream,
-                    CalculateContentMD5Header = true
+                    InputStream = inputStream
                 };
 
                 var up2Response = s3EncryptionClient.UploadPart(uploadRequest);
@@ -287,8 +284,7 @@ namespace Amazon.Extensions.S3.Encryption.IntegrationTests.Utilities
                     UploadId = initResponse.UploadId,
                     PartNumber = 3,
                     InputStream = inputStream,
-                    IsLastPart = true,
-                    CalculateContentMD5Header = true
+                    IsLastPart = true
                 };
 
                 var up3Response = s3EncryptionClient.UploadPart(uploadRequest);
@@ -398,8 +394,7 @@ namespace Amazon.Extensions.S3.Encryption.IntegrationTests.Utilities
                 Key = $"key-{Guid.NewGuid()}",
                 FilePath = filePath,
                 InputStream = inputStreamBytes == null ? null : new MemoryStream(inputStreamBytes),
-                ContentBody = contentBody,
-                CalculateContentMD5Header = true
+                ContentBody = contentBody
             };
 
             var response = s3EncryptionClient.PutObject(request);

--- a/test/IntegrationTests/netstandard/Utilities/EncryptionTestsUtils.cs
+++ b/test/IntegrationTests/netstandard/Utilities/EncryptionTestsUtils.cs
@@ -199,8 +199,7 @@ namespace Amazon.Extensions.S3.Encryption.IntegrationTests.Utilities
                     UploadId = initResponse.UploadId,
                     PartNumber = 1,
                     PartSize = 5 * MegaBytesSize,
-                    InputStream = inputStream,
-                    CalculateContentMD5Header = true
+                    InputStream = inputStream
                 };
 
                 UploadPartResponse up1Response =
@@ -214,8 +213,7 @@ namespace Amazon.Extensions.S3.Encryption.IntegrationTests.Utilities
                     UploadId = initResponse.UploadId,
                     PartNumber = 2,
                     PartSize = 5 * MegaBytesSize,
-                    InputStream = inputStream,
-                    CalculateContentMD5Header = true
+                    InputStream = inputStream
                 };
 
                 UploadPartResponse up2Response =
@@ -229,8 +227,7 @@ namespace Amazon.Extensions.S3.Encryption.IntegrationTests.Utilities
                     UploadId = initResponse.UploadId,
                     PartNumber = 3,
                     InputStream = inputStream,
-                    IsLastPart = true,
-                    CalculateContentMD5Header = true
+                    IsLastPart = true
                 };
 
                 UploadPartResponse up3Response =
@@ -336,8 +333,7 @@ namespace Amazon.Extensions.S3.Encryption.IntegrationTests.Utilities
                 Key = $"key-{Guid.NewGuid()}",
                 FilePath = filePath,
                 InputStream = inputStreamBytes == null ? null : new MemoryStream(inputStreamBytes),
-                ContentBody = contentBody,
-                CalculateContentMD5Header = true
+                ContentBody = contentBody
             };
             PutObjectResponse response = await s3EncryptionClient.PutObjectAsync(request).ConfigureAwait(false);
             await TestGetAsync(request.Key, expectedContent, s3DecryptionClient, bucketName).ConfigureAwait(false);


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-7990

*Description of changes:*
* Update .NET SDK dependencies to v4.0.0-preview8
* Stopped using `CalculateContentMD5Header` since it is obsolete and redundant as the new S3 package has it's behavior by default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
