### PR TITLE
chore: update docfx target framework

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -12,7 +12,7 @@
       "dest": "api",
       "filter": "filter.yml",
       "properties": {
-        "targetFramework": "net45"
+        "targetFramework": "net472"
       }
     }
   ],


### PR DESCRIPTION
## Description
Update docfx target framework which was missed in the V4 upgrade since net45 is no longer supported
