### PR TITLE
Fix tests for .NET Framework 3.5

### DIFF
--- a/test/UnitTests/S3ecImplementedCryptographicOperationsTest.cs
+++ b/test/UnitTests/S3ecImplementedCryptographicOperationsTest.cs
@@ -108,7 +108,7 @@ namespace Amazon.Extensions.S3.Encryption.UnitTests
             Assert.False(isEqualB, "value missing last byte, value");
         }
 
-#if BCL35
+#if !BCL35
         [Fact]
         public static void HasCorrectMethodImpl()
         {


### PR DESCRIPTION
## Description
Fix tests for .NET Framework 3.5. In the last PR I meant to exclude the test for .NET Framework 3.5 but forgot the not operator.
