### PR TITLE
fix: CommitmentPolicy bypass with v2-v3 keys together

### DIFF
--- a/.autover/changes/129fb113-897e-469e-a86b-074bd5113944.json
+++ b/.autover/changes/129fb113-897e-469e-a86b-074bd5113944.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Amazon.Extensions.S3.Encryption",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "CommitmentPolicy bypass fix when v2-v3 keys are mixed"
+      ]
+    }
+  ]
+}

--- a/src/Util/ContentMetaDataV3Utils.cs
+++ b/src/Util/ContentMetaDataV3Utils.cs
@@ -13,47 +13,47 @@ namespace Amazon.Extensions.S3.Encryption.Util.ContentMetaDataUtils
         //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
         //= type=implication
         //# The "x-amz-meta-" prefix is automatically added by the S3 server and MUST NOT be included in implementation code.
-        
+
         //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
         //= type=implication
         //# - This mapkey ("x-amz-c") SHOULD be represented by a constant named "CONTENT_CIPHER_V3" or similar in the implementation code.
         internal const string ContentCipherV3 = EncryptionUtils.XAmzPrefix + "c";
-        
+
         //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
         //= type=implication
         //# - This mapkey ("x-amz-3") SHOULD be represented by a constant named "ENCRYPTED_DATA_KEY_V3" or similar in the implementation code.
         internal const string EncryptedDataKeyV3 = EncryptionUtils.XAmzPrefix + "3";
-        
+
         //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
         //= type=implication
         //# - This mapkey ("x-amz-w") SHOULD be represented by a constant named "ENCRYPTED_DATA_KEY_ALGORITHM_V3" or similar in the implementation code.
         internal const string EncryptedDataKeyAlgorithmV3 = EncryptionUtils.XAmzPrefix + "w";
-        
+
         //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
         //= type=implication
         //# - This mapkey ("x-amz-d") SHOULD be represented by a constant named "KEY_COMMITMENT_V3" or similar in the implementation code.
         internal const string KeyCommitmentV3 = EncryptionUtils.XAmzPrefix + "d";
-        
+
         //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
         //= type=implication
         //# - This mapkey ("x-amz-i") SHOULD be represented by a constant named "MESSAGE_ID_V3" or similar in the implementation code.
         internal const string MessageIdV3 = EncryptionUtils.XAmzPrefix + "i";
-        
+
         //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
         //= type=implication
         //# - This mapkey ("x-amz-m") SHOULD be represented by a constant named "MAT_DESC_V3" or similar in the implementation code.
         internal const string MatDescV3 = EncryptionUtils.XAmzPrefix + "m";
-        
+
         //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
         //= type=implication
         //# - This mapkey ("x-amz-t") SHOULD be represented by a constant named "ENCRYPTION_CONTEXT_V3" or similar in the implementation code.
         internal const string EncryptionContextV3 = EncryptionUtils.XAmzPrefix + "t";
-        
+
         // v3 compressed algorithm values
         internal const string XAmzWrapAlgAesGcmV3 = "02";
         internal const string WrapAlgKmsContextV3 = "12";
         internal const string XAmzWrapAlgRsaOaepSha1V3 = "22";
-        
+
         /// <summary>
         /// Determines if an object has V3 encryption schema (MetaData or Instruction File mode).
         /// </summary>
@@ -63,9 +63,27 @@ namespace Amazon.Extensions.S3.Encryption.Util.ContentMetaDataUtils
             MetadataCollection objectMetadata
         )
         {
-            return objectMetadata[ContentCipherV3] != null;
+            //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
+            //# In the V3 format, the mapkeys "x-amz-c", "x-amz-d", and "x-amz-i" MUST be stored exclusively in the Object Metadata.
+            bool hasAnyV3Key = objectMetadata[ContentCipherV3] != null || objectMetadata[KeyCommitmentV3] != null ||
+                               objectMetadata[MessageIdV3] != null;
+
+            if (hasAnyV3Key)
+            {
+                //= ../specification/s3-encryption/data-format/content-metadata.md#determining-s3ec-object-status
+                //# If there are multiple mapkeys which are meant to be exclusive, such as "x-amz-key", "x-amz-key-v2", and "x-amz-3" then the S3EC SHOULD throw an exception.
+                if (EncryptionUtils.V1V2Keys.Any(key => objectMetadata[key] != null))
+                {
+                    throw new InvalidDataException(
+                        "Object metadata contains mapkeys from multiple exclusive format versions. " +
+                        "The object may have been tampered with.");
+                }
+            }
+
+            return objectMetadata[ContentCipherV3] != null && objectMetadata[KeyCommitmentV3] != null &&
+                   objectMetadata[MessageIdV3] != null;
         }
-        
+
         /// <summary>
         /// Determines if an object has V3 encryption schema (Instruction File mode)
         /// </summary>
@@ -75,14 +93,14 @@ namespace Amazon.Extensions.S3.Encryption.Util.ContentMetaDataUtils
         {
             var hasEncryptedKey = instructionFileContent.ContainsKey(EncryptedDataKeyV3);
             var hasAlgorithm = instructionFileContent.ContainsKey(EncryptedDataKeyAlgorithmV3);
-    
+
             if (hasEncryptedKey != hasAlgorithm)
                 throw new InvalidDataException($"Invalid metadata. The metadata is missing either {EncryptedDataKeyV3} or " +
                                                $"{EncryptedDataKeyAlgorithmV3} but not both.");
-            
+
             return hasEncryptedKey;
         }
-        
+
         internal static bool IsV3ObjectInMetaDataMode(
             MetadataCollection objectMetadata
         )
@@ -92,38 +110,38 @@ namespace Amazon.Extensions.S3.Encryption.Util.ContentMetaDataUtils
             return objectMetadata[EncryptedDataKeyV3] != null && objectMetadata[KeyCommitmentV3] != null &&
                    objectMetadata[MessageIdV3] != null;
         }
-        
+
         internal static void ValidateV3ObjectMetadata(MetadataCollection metadata, bool isNonKmsMaterial)
         {
             //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
             //# In the V3 format, the mapkeys "x-amz-c", "x-amz-d", and "x-amz-i" MUST be stored exclusively in the Object Metadata.
-            
+
             //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
             //# - The mapkey "x-amz-c" MUST be present for V3 format objects.
             if (metadata[ContentCipherV3] == null)
                 throw new InvalidDataException($"V3 format requires {ContentCipherV3} metadata");
-            
+
             //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
             //# - The mapkey "x-amz-3" MUST be present for V3 format objects.
             if (metadata[EncryptedDataKeyV3] == null)
                 throw new InvalidDataException($"V3 format requires {EncryptedDataKeyV3} metadata");
-            
+
             //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
             //# - The mapkey "x-amz-w" MUST be present for V3 format objects.
             if (metadata[EncryptedDataKeyAlgorithmV3] == null)
                 throw new InvalidDataException($"V3 format requires {EncryptedDataKeyAlgorithmV3} metadata");
-            
+
             //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
             //# In the V3 format, the mapkeys "x-amz-c", "x-amz-d", and "x-amz-i" MUST be stored exclusively in the Object Metadata.
-            
+
             //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
             //# - The mapkey "x-amz-d" MUST be present for V3 format objects.
             if (metadata[KeyCommitmentV3] == null)
                 throw new InvalidDataException($"V3 format requires {KeyCommitmentV3} metadata");
-            
+
             //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
             //# In the V3 format, the mapkeys "x-amz-c", "x-amz-d", and "x-amz-i" MUST be stored exclusively in the Object Metadata.
-            
+
             //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
             //# - The mapkey "x-amz-i" MUST be present for V3 format objects.
             if (metadata[MessageIdV3] == null)
@@ -137,7 +155,7 @@ namespace Amazon.Extensions.S3.Encryption.Util.ContentMetaDataUtils
         {
             //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
             //# In the V3 format, the mapkeys "x-amz-c", "x-amz-d", and "x-amz-i" MUST be stored exclusively in the Object Metadata.
-            
+
             //= ../specification/s3-encryption/data-format/metadata-strategy.md#v3-instruction-files
             //# - The V3 message format MUST store the mapkey "x-amz-c" and its value in the Object Metadata when writing with an Instruction File.
             if (objectMetadata[ContentCipherV3] == null)
@@ -145,16 +163,16 @@ namespace Amazon.Extensions.S3.Encryption.Util.ContentMetaDataUtils
                     $"V3 instruction file mode requires {ContentCipherV3} in object metadata");
             //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
             //# In the V3 format, the mapkeys "x-amz-c", "x-amz-d", and "x-amz-i" MUST be stored exclusively in the Object Metadata.
-            
+
             //= ../specification/s3-encryption/data-format/metadata-strategy.md#v3-instruction-files
             //# - The V3 message format MUST store the mapkey "x-amz-d" and its value in the Object Metadata when writing with an Instruction File.
             if (objectMetadata[KeyCommitmentV3] == null)
                 throw new InvalidDataException(
                     $"V3 instruction file mode requires {KeyCommitmentV3} in object metadata");
-            
+
             //= ../specification/s3-encryption/data-format/content-metadata.md#content-metadata-mapkeys
             //# In the V3 format, the mapkeys "x-amz-c", "x-amz-d", and "x-amz-i" MUST be stored exclusively in the Object Metadata.
-            
+
             //= ../specification/s3-encryption/data-format/metadata-strategy.md#v3-instruction-files
             //# - The V3 message format MUST store the mapkey "x-amz-i" and its value in the Object Metadata when writing with an Instruction File.
             if (objectMetadata[MessageIdV3] == null)
@@ -179,12 +197,12 @@ namespace Amazon.Extensions.S3.Encryption.Util.ContentMetaDataUtils
             //# - The V3 message format MUST store the mapkey "x-amz-3" and its value in the Instruction File.
             if (!instructionFileContent.ContainsKey(EncryptedDataKeyV3))
                 throw new InvalidDataException($"V3 instruction file requires {EncryptedDataKeyV3}");
-            
+
             //= ../specification/s3-encryption/data-format/metadata-strategy.md#v3-instruction-files
             //# - The V3 message format MUST store the mapkey "x-amz-w" and its value in the Instruction File.
             if (!instructionFileContent.ContainsKey(EncryptedDataKeyAlgorithmV3))
                 throw new InvalidDataException($"V3 instruction file requires {EncryptedDataKeyAlgorithmV3}");
-            
+
             //= ../specification/s3-encryption/data-format/metadata-strategy.md#v3-instruction-files
             //= type=exception
             //# - The V3 message format MUST store the mapkey "x-amz-t" and its value (when present in the content metadata) in the Instruction File.
@@ -208,16 +226,16 @@ namespace Amazon.Extensions.S3.Encryption.Util.ContentMetaDataUtils
             //= ../specification/s3-encryption/data-format/content-metadata.md#determining-s3ec-object-status
             //= type=citation
             //# If there are multiple mapkeys which are meant to be exclusive, such as "x-amz-key", "x-amz-key-v2", and "x-amz-3" then the S3EC SHOULD throw an exception.                                                                                                                   
-                                                                                                                                                                                                                                                                                             
+
             // Check for conflicting V1/V2 keys in object metadata                                                                                                                                                                                                                           
-            if (EncryptionUtils.V1V2Keys.Any(key => objectMetadata[key] != null))                                                                                                                                                                                                                            
-                throw new InvalidDataException("Invalid V3 instruction file: object metadata contains conflicting V1/V2 keys");                                                                                                                                                              
-                                                                                                                                                                                                                                                                                             
+            if (EncryptionUtils.V1V2Keys.Any(key => objectMetadata[key] != null))
+                throw new InvalidDataException("Invalid V3 instruction file: object metadata contains conflicting V1/V2 keys");
+
             // Check for conflicting V1/V2 keys in instruction file
             if (EncryptionUtils.V1V2Keys.Any(key => instructionFileContent.ContainsKey(key)))
                 throw new InvalidDataException("Invalid V3 instruction file: instruction file contains conflicting V1/V2 encrypted keys");
         }
-        
+
         /// <summary>
         /// Compresses V2 wrap algorithm to V3 format
         /// </summary>

--- a/test/UnitTests/CommitmentPolicyBypassTests.cs
+++ b/test/UnitTests/CommitmentPolicyBypassTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using Amazon.Extensions.S3.Encryption.Internal;
 using Amazon.Extensions.S3.Encryption.Primitives;
 using Amazon.Extensions.S3.Encryption.Util.ContentMetaDataUtils;
@@ -110,7 +111,7 @@ namespace Amazon.Extensions.S3.Encryption.UnitTests
             metadata["x-amz-c"] = "115"; // attacker injects single V3 header
 
             // Any V3 key alongside V1/V2 keys → throws per spec exclusive key rule
-            Assert.ThrowsAny<Exception>(() =>
+            Assert.Throws<InvalidDataException>(() =>
                 InvokeThrowIfDecryptNonCommitingDisabled(RequireDecryptConfig, metadata));
         }
 
@@ -125,7 +126,7 @@ namespace Amazon.Extensions.S3.Encryption.UnitTests
             metadata["x-amz-d"] = "fakecommitment";
 
             // Any V3 key alongside V1/V2 keys → throws per spec exclusive key rule
-            Assert.ThrowsAny<Exception>(() =>
+            Assert.Throws<InvalidDataException>(() =>
                 InvokeThrowIfDecryptNonCommitingDisabled(RequireDecryptConfig, metadata));
         }
 
@@ -141,7 +142,7 @@ namespace Amazon.Extensions.S3.Encryption.UnitTests
             metadata["x-amz-i"] = "fakemessageid";
 
             // IsV3Object detects V3 markers + V1/V2 keys → throws InvalidDataException per spec
-            Assert.ThrowsAny<Exception>(() =>
+            Assert.Throws<InvalidDataException>(() =>
                 InvokeThrowIfDecryptNonCommitingDisabled(RequireDecryptConfig, metadata));
         }
 
@@ -157,7 +158,7 @@ namespace Amazon.Extensions.S3.Encryption.UnitTests
             metadata["x-amz-i"] = "fakemessageid";
 
             // IsV3Object detects V3 markers + V1/V2 keys → throws InvalidDataException per spec
-            Assert.ThrowsAny<Exception>(() =>
+            Assert.Throws<InvalidDataException>(() =>
                 InvokeThrowIfDecryptNonCommitingDisabled(RequireDecryptConfig, metadata));
         }
 

--- a/test/UnitTests/CommitmentPolicyBypassTests.cs
+++ b/test/UnitTests/CommitmentPolicyBypassTests.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Generic;
+using Amazon.Extensions.S3.Encryption.Internal;
+using Amazon.Extensions.S3.Encryption.Primitives;
+using Amazon.Extensions.S3.Encryption.Util.ContentMetaDataUtils;
+using Amazon.S3.Model;
+using Moq;
+using Xunit;
+
+namespace Amazon.Extensions.S3.Encryption.UnitTests
+{
+    /// <summary>
+    /// Tests that verify the commitment policy cannot be bypassed by attacker-controlled metadata.
+    /// 
+    /// Threat model: S3 server or MITM is untrusted. An attacker can inject arbitrary headers
+    /// on a V2 (non-committed) ciphertext response. The commitment policy gate must reject
+    /// any object that has V1/V2 envelope keys present, regardless of spoofed V3 headers.
+    /// </summary>
+    public class CommitmentPolicyBypassTests
+    {
+        private static readonly EncryptionMaterialsV4 Materials =
+            new EncryptionMaterialsV4("dummy-key-id", KmsType.KmsContext, new Dictionary<string, string>());
+
+        private static readonly AmazonS3CryptoConfigurationV4 RequireDecryptConfig =
+            new AmazonS3CryptoConfigurationV4(SecurityProfile.V4, CommitmentPolicy.RequireEncryptRequireDecrypt, ContentEncryptionAlgorithm.AesGcmWithCommitment);
+
+        private static readonly AmazonS3CryptoConfigurationV4 AllowDecryptConfig =
+            new AmazonS3CryptoConfigurationV4(SecurityProfile.V4AndLegacy, CommitmentPolicy.RequireEncryptAllowDecrypt, ContentEncryptionAlgorithm.AesGcmWithCommitment);
+
+        /// <summary>
+        /// Invokes the actual ThrowIfDecryptNonCommitingDisabled method on SetupDecryptionHandlerV4.
+        /// </summary>
+        private static void InvokeThrowIfDecryptNonCommitingDisabled(
+            AmazonS3CryptoConfigurationV4 config, MetadataCollection metadata)
+        {
+            var client = new AmazonS3EncryptionClientV4(config, Materials);
+            var handler = new Mock<SetupDecryptionHandlerV4>(client);
+            handler.CallBase = true;
+
+            Utils.RunInstanceMethod(
+                typeof(SetupDecryptionHandlerV4),
+                "ThrowIfDecryptNonCommitingDisabled",
+                handler.Object,
+                new object[] { metadata });
+        }
+
+        #region IsV3Object detection tests
+
+        [Fact]
+        public void IsV3Object_WithAllThreeRequiredHeaders_ReturnsTrue()
+        {
+            var metadata = new MetadataCollection();
+            metadata["x-amz-c"] = "115";
+            metadata["x-amz-d"] = "base64commitment";
+            metadata["x-amz-i"] = "base64messageid";
+
+            Assert.True(ContentMetaDataV3Utils.IsV3Object(metadata));
+        }
+
+        [Fact]
+        public void IsV3Object_WithOnlyContentCipher_ReturnsFalse()
+        {
+            // Attacker injects only x-amz-c on a V2 object
+            var metadata = new MetadataCollection();
+            metadata["x-amz-c"] = "115";
+
+            Assert.False(ContentMetaDataV3Utils.IsV3Object(metadata));
+        }
+
+        [Fact]
+        public void IsV3Object_WithContentCipherAndKeyCommitment_ReturnsFalse()
+        {
+            // Attacker injects x-amz-c and x-amz-d but not x-amz-i
+            var metadata = new MetadataCollection();
+            metadata["x-amz-c"] = "115";
+            metadata["x-amz-d"] = "garbage";
+
+            Assert.False(ContentMetaDataV3Utils.IsV3Object(metadata));
+        }
+
+        [Fact]
+        public void IsV3Object_WithContentCipherAndMessageId_ReturnsFalse()
+        {
+            // Attacker injects x-amz-c and x-amz-i but not x-amz-d
+            var metadata = new MetadataCollection();
+            metadata["x-amz-c"] = "115";
+            metadata["x-amz-i"] = "garbage";
+
+            Assert.False(ContentMetaDataV3Utils.IsV3Object(metadata));
+        }
+
+        [Fact]
+        public void IsV3Object_EmptyMetadata_ReturnsFalse()
+        {
+            var metadata = new MetadataCollection();
+            Assert.False(ContentMetaDataV3Utils.IsV3Object(metadata));
+        }
+
+        #endregion
+
+        #region Commitment policy bypass attack scenarios — calls actual ThrowIfDecryptNonCommitingDisabled
+
+        [Fact]
+        public void CommitmentGate_V2ObjectWithSpoofedContentCipherOnly_MustThrow()
+        {
+            //= ../specification/s3-encryption/decryption.md#key-commitment
+            //= type=test
+            //# The S3EC MUST validate the algorithm suite used for decryption against the key commitment policy before attempting to decrypt the content ciphertext.
+            var metadata = CreateV2Metadata();
+            metadata["x-amz-c"] = "115"; // attacker injects single V3 header
+
+            // Any V3 key alongside V1/V2 keys → throws per spec exclusive key rule
+            Assert.ThrowsAny<Exception>(() =>
+                InvokeThrowIfDecryptNonCommitingDisabled(RequireDecryptConfig, metadata));
+        }
+
+        [Fact]
+        public void CommitmentGate_V2ObjectWithSpoofedContentCipherAndKeyCommitment_MustThrow()
+        {
+            //= ../specification/s3-encryption/decryption.md#key-commitment
+            //= type=test
+            //# If the commitment policy requires decryption using a committing algorithm suite, and the algorithm suite associated with the object does not support key commitment, then the S3EC MUST throw an exception.
+            var metadata = CreateV2Metadata();
+            metadata["x-amz-c"] = "115";
+            metadata["x-amz-d"] = "fakecommitment";
+
+            // Any V3 key alongside V1/V2 keys → throws per spec exclusive key rule
+            Assert.ThrowsAny<Exception>(() =>
+                InvokeThrowIfDecryptNonCommitingDisabled(RequireDecryptConfig, metadata));
+        }
+
+        [Fact]
+        public void CommitmentGate_V2ObjectWithAllV3HeadersSpoofed_MustThrow()
+        {
+            //= ../specification/s3-encryption/key-commitment.md#commitment-policy
+            //= type=test
+            //# When the commitment policy is REQUIRE_ENCRYPT_REQUIRE_DECRYPT, the S3EC MUST NOT allow decryption using algorithm suites which do not support key commitment.
+            var metadata = CreateV2Metadata();
+            metadata["x-amz-c"] = "115";
+            metadata["x-amz-d"] = "fakecommitment";
+            metadata["x-amz-i"] = "fakemessageid";
+
+            // IsV3Object detects V3 markers + V1/V2 keys → throws InvalidDataException per spec
+            Assert.ThrowsAny<Exception>(() =>
+                InvokeThrowIfDecryptNonCommitingDisabled(RequireDecryptConfig, metadata));
+        }
+
+        [Fact]
+        public void CommitmentGate_V1ObjectWithAllV3HeadersSpoofed_MustThrow()
+        {
+            var metadata = new MetadataCollection();
+            metadata["x-amz-key"] = "base64encryptedkey";
+            metadata["x-amz-iv"] = "base64iv";
+            metadata["x-amz-matdesc"] = "{}";
+            metadata["x-amz-c"] = "115";
+            metadata["x-amz-d"] = "fakecommitment";
+            metadata["x-amz-i"] = "fakemessageid";
+
+            // IsV3Object detects V3 markers + V1/V2 keys → throws InvalidDataException per spec
+            Assert.ThrowsAny<Exception>(() =>
+                InvokeThrowIfDecryptNonCommitingDisabled(RequireDecryptConfig, metadata));
+        }
+
+        [Fact]
+        public void CommitmentGate_LegitimateV3MetadataMode_MustNotThrow()
+        {
+            // Legitimate V3 object: has V3 headers and NO V1/V2 keys
+            var metadata = new MetadataCollection();
+            metadata["x-amz-c"] = "115";
+            metadata["x-amz-d"] = "realcommitment";
+            metadata["x-amz-i"] = "realmessageid";
+            metadata["x-amz-3"] = "realencryptedkey";
+            metadata["x-amz-w"] = "12";
+
+            // Should not throw
+            InvokeThrowIfDecryptNonCommitingDisabled(RequireDecryptConfig, metadata);
+        }
+
+        [Fact]
+        public void CommitmentGate_LegitimateV3InstructionFileMode_MustNotThrow()
+        {
+            // In instruction file mode: x-amz-c/d/i in metadata, x-amz-3 NOT in metadata
+            // No V1/V2 keys present
+            var metadata = new MetadataCollection();
+            metadata["x-amz-c"] = "115";
+            metadata["x-amz-d"] = "realcommitment";
+            metadata["x-amz-i"] = "realmessageid";
+
+            // Should not throw
+            InvokeThrowIfDecryptNonCommitingDisabled(RequireDecryptConfig, metadata);
+        }
+
+        [Fact]
+        public void CommitmentGate_V2ObjectNoSpoofedHeaders_MustThrow()
+        {
+            // Normal V2 object — policy must reject
+            var metadata = CreateV2Metadata();
+
+            Assert.Throws<ArgumentException>(() =>
+                InvokeThrowIfDecryptNonCommitingDisabled(RequireDecryptConfig, metadata));
+        }
+
+        [Fact]
+        public void CommitmentGate_V2ObjectWithAllowDecryptPolicy_MustNotThrow()
+        {
+            //= ../specification/s3-encryption/key-commitment.md#commitment-policy
+            //= type=test
+            //# When the commitment policy is REQUIRE_ENCRYPT_ALLOW_DECRYPT, the S3EC MUST allow decryption using algorithm suites which do not support key commitment.
+            var metadata = CreateV2Metadata();
+
+            // Should not throw with REQUIRE_ENCRYPT_ALLOW_DECRYPT
+            InvokeThrowIfDecryptNonCommitingDisabled(AllowDecryptConfig, metadata);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static MetadataCollection CreateV2Metadata()
+        {
+            var metadata = new MetadataCollection();
+            metadata["x-amz-key-v2"] = "base64encryptedkey";
+            metadata["x-amz-iv"] = "base64iv";
+            metadata["x-amz-cek-alg"] = "AES/GCM/NoPadding";
+            metadata["x-amz-wrap-alg"] = "kms+context";
+            metadata["x-amz-tag-len"] = "128";
+            metadata["x-amz-matdesc"] = "{}";
+            return metadata;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
`ThrowIfDecryptNonCommitingDisabled` was intended to enforce `CommitmentPolicy.RequireEncryptRequireDecrypt` by rejecting non-committed (V2/V1) objects. However, the gate is skipped when IsV3Object(metadata) returns true when `x-amz-c (ContentCipherV3)` header is present but the object doesn't have full / valid V3 headers. The logic then proceeds to decrypt using V1/V2 headers which shouldn't happen when  `CommitmentPolicy.RequireEncryptRequireDecrypt` is true.

Internal issue: `P415885985`

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit Tests and Test Server here:  https://github.com/aws/amazon-s3-encryption-client-python/pull/197
## Breaking Changes Assessment

1. Identify all breaking changes including the following details:
    * What functionality was changed?
    * How will this impact customers?
    * Why does this need to be a breaking change and what are the most notable non-breaking alternatives?
    * Are best practices being followed?
    * How have you tested this breaking change?
2. Has a senior/+ engineer been assigned to review this PR?

## Screenshots (if appropriate)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License
<!--- The SDK is released under the [Apache 2.0 license][license], so any code you submit will be released under that license -->
<!--- For substantial contributions, we may ask you to sign a [Contributor License Agreement (CLA)][cla] -->
<!--- Put an `x` in the below box if you confirm that this request can be released under the Apache 2 license -->
- [ ] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement